### PR TITLE
feat: Add `ogimage` class instead of custom `gaia` class

### DIFF
--- a/themes/ogimage.css
+++ b/themes/ogimage.css
@@ -11,8 +11,8 @@ section {
   height: 630px;
 }
 
-section.gaia{
-  background-color: 	royalblue;
+section.ogimage{
+  background-color: 	whitesmoke;
 }
 
 section h1 {


### PR DESCRIPTION
The background color of `ogimage` class is `whitesmoke`.
